### PR TITLE
Updated Expreso.parse to handle invalid expressions

### DIFF
--- a/lib/expreso.ex
+++ b/lib/expreso.ex
@@ -60,8 +60,12 @@ defmodule Expreso do
   end
 
   def lex(expr) do
-    {:ok, tokens, _} = expr |> :expreso_lexer.string()
-    {:ok, tokens}
+    case :expreso_lexer.string(expr) do
+      {:ok, tokens, _} ->
+        {:ok, tokens}
+      {:error, reason, line} ->
+        {:error, reason, line}
+    end
   end
 
   @doc """

--- a/test/expreso_parse_test.exs
+++ b/test/expreso_parse_test.exs
@@ -68,4 +68,10 @@ defmodule Expreso.ParserTest do
               {:number, 2}}}
     assert {:ok, exp} == Expreso.parse(str)
   end
+
+  test "parse invalid expression" do
+    str = "iam = 'invalid"
+    assert {:error, {1, :expreso_lexer, {:illegal, '\'invalid'}}, 1} == Expreso.parse(str)
+  end
+
 end


### PR DESCRIPTION
Thanks for this very nice library. 
I had been using it with user generated expressions which might be invalid sometimes.

When someone enters an invalid expression like: iam = 'Invalid
We get a MatchError, this is prevented by the update in this pull request which returns an error tuple.

Example to reproduce the MatchError:
```
Expreso.parse("iam = 'invalid")
** (CaseClauseError) no case clause matching: {:error, {1, :expreso_lexer, {:illegal, '\'invalid'}}, 1}
     code: IO.inspect Expreso.parse(str)
     stacktrace:
       (expreso) lib/expreso.ex:63: Expreso.lex/1
       (expreso) lib/expreso.ex:49: Expreso.parse/1
       test/expreso_parse_test.exs:74: (test)
```